### PR TITLE
Handling absent optional initial properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "John Ralston",
   "description": "outer-state is a simple but extremely powerful state management facility for ReactJS applications. It promotes and facilitates keeping 100% of the business logic out of React. Instead it allows all logic to be in vanilla TypeScript/JavaScript files. This massively reduces application complexity. It also dramatically simplifies unit testing.",
   "homepage": "https://github.com/JohnERalston/outer-state",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -63,9 +63,6 @@ export function createStore<Store>(initialValues: Store) {
   function setStoreValues(partial: Partial<Store>) {
     const keys = Object.keys(partial);
     keys.forEach(key => {
-      if (!(store as any).hasOwnProperty([key])) {
-        return;
-      }
       (store as any)[key] = (partial as any)[key];
     });
     store = { ...store };

--- a/test/lib.test.tsx
+++ b/test/lib.test.tsx
@@ -190,12 +190,15 @@ describe('outer-state', () => {
 
   it('will update optional properties not set in createStore', async () => {
     expect(testStore.data().optional).toBeUndefined();
+    expect(testStore.data().green).not.toBe(-100);
     act(() => {
       testStore.updateStore({
         optional: 2,
+        green: -100,
       });
     });
     expect(testStore.data().optional).toBe(2);
+    expect(testStore.data().green).toBe(-100);
   });
 
   it('will update parent', async () => {

--- a/test/lib.test.tsx
+++ b/test/lib.test.tsx
@@ -6,6 +6,7 @@ interface TestStore {
   parent: number;
   yellow: number;
   green: number;
+  optional?: number;
 }
 
 const [defaultParentVal, defaultYellowVal, defaultGreenVal] = [0, 100, 200];
@@ -187,20 +188,14 @@ describe('outer-state', () => {
     expect(greenRender).toHaveBeenCalledTimes(2);
   });
 
-  it('will ignore unmatched update property keys', async () => {
-    render(<Parent />);
+  it('will update optional properties not set in createStore', async () => {
+    expect(testStore.data().optional).toBeUndefined();
     act(() => {
       testStore.updateStore({
-        parent: 66,
-        yellow: 77,
-        green: 88,
-        //@ts-ignore
-        unmatched: 99,
+        optional: 2,
       });
     });
-    await waitFor(() => expect(getYellowVal()).toBe(77));
-    expect(getParentVal()).toBe(66);
-    expect(getGreenVal()).toBe(88);
+    expect(testStore.data().optional).toBe(2);
   });
 
   it('will update parent', async () => {


### PR DESCRIPTION
When a store prop is optional and not included in the initial createStore, updateStore should update it when specified